### PR TITLE
Compatibility issues with fullscreen and multiple monitors on Gnome

### DIFF
--- a/nadeocr/GUI/functions/google_provider.py
+++ b/nadeocr/GUI/functions/google_provider.py
@@ -99,7 +99,7 @@ class GoogleProvider:
                 print(result)
 
         except Exception as error:
-            self.parentwindow_toast.showToaster(
+            self.parent.window_toast.showToaster(
                 notification_pos, "No se encontro texto a escanear."
             )
             print(error)

--- a/nadeocr/GUI/widgets/crop_widget.py
+++ b/nadeocr/GUI/widgets/crop_widget.py
@@ -27,7 +27,6 @@ class CropWidget(QWidget):
         self.setWindowFlags(
             Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint | Qt.SubWindow
         )
-        self.setWindowState(Qt.WindowMaximized | Qt.WindowFullScreen)
         self.setStyleSheet("background:transparent;")
         self.setCursor(QtGui.QCursor(Qt.CrossCursor))
 
@@ -65,9 +64,8 @@ class CropWidget(QWidget):
         self.width = total_width
         self.height = total_height
 
+        self.show()
         self.setGeometry(self.x, self.y, self.width, self.height)
-
-        self.showFullScreen()
 
     def paintEvent(self, event):
         trans = QtGui.QColor(0, 0, 0, 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pynput==1.7.6
 pyperclip==1.8.2
 PyQt5==5.15.7
 PySide6==6.3.1
+screeninfo==0.8.1


### PR DESCRIPTION
* Fix typo on `parentwindow_toast` that was raising an exception when not capturing any text.
* Add missing dependency `screeninfo==0.8.1` to `requirements.txt`
* Use `self.show()` and remove flags to Fullscreen window. Without this, the app was only rendering the grayed area over the main display on Gnome 42.4.
  * Also, from this post the `self.show()` has to be called before `self.setGeometry()`, otherwise the area won´t be resized: https://forum.qt.io/topic/66935/fullscreen-over-multiple-screens-qt-5-6/13